### PR TITLE
issue template 選択のための config.yml を追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true


### PR DESCRIPTION
## What
issue template 選択のための config.yml を追加

## Why
#2 で追加した issue template だけだと、以下のように template パラメータを指定して issue 作成画面を開かないと、 good first issue の issue を作成できなかったため。

- 例: https://github.com/groove-x/lovot-qa/issues/new?template=good-first-issue.md

どうやら [config.yml が必要](https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) そうでした。

各種プロジェクトの config.yml 設定例
- https://github.com/search?q=blank_issues_enabled%3A+true+path%3A.github%2FISSUE_TEMPLATE&type=code

config.yml が存在するリポジトリの issue 作成画面例
- https://github.com/GoPlugin/Plugin/issues/new/choose